### PR TITLE
Updating the Command comment to reflect the true pattern that is being matched against

### DIFF
--- a/src/pivotal-search.coffee
+++ b/src/pivotal-search.coffee
@@ -6,7 +6,7 @@
 #   HUBOT_PIVOTAL_PROJECTS
 #
 # Commands:
-#   hubot piv|otal <string> - returns list of matching Pivotal Tracker stories
+#   hubot piv|pivotal <string> - returns list of matching Pivotal Tracker stories
 #
 # Notes:
 #   <optional notes required for the script>


### PR DESCRIPTION
I'm opening this because when doing a `hubot help piv` it returns a pattern that is not accurate.

```
hubot piv|otal <string> - returns list of matching Pivotal Tracker stories
```

When searching with `hubot piv string` it works as expected but when you do `hubot otal string` nothing happens.  I would never want to do a `hubot otal string` so I was glad to see that it wasn't actually supported.
