### PR TITLE
Send search results in single message

### DIFF
--- a/src/pivotal-search.coffee
+++ b/src/pivotal-search.coffee
@@ -28,9 +28,11 @@ module.exports = (robot) ->
           msg.send "Pivotal says: #{err}"
           return
         if res.statusCode != 500
+          results = []
           stories = JSON.parse body
           for story in stories
-            message = "#{story.id} #{story.name}"
-            message += " (#{story.current_state})" if story.current_state
-            message += " - #{story.url}"
-            msg.send message
+            result = "#{story.id} #{story.name}"
+            result += " (#{story.current_state})" if story.current_state
+            result += " - #{story.url}"
+            results.push result
+          msg.send results.join("\n")


### PR DESCRIPTION
When a search returns 10+ stories quickly and posts each message individually, [Slack rate limits hubot](https://github.com/hubot-scripts/hubot-circleci/pull/12). Slack's hubot connector [isn't set up](https://github.com/slackhq/hubot-slack/issues/151) to handle rate limits so hubot gets disconnected and doesn't reconnect. This change combines the search results into a single message to avoid these rate limits and keep your hubot happy and healthy!
